### PR TITLE
Fix rendering bug caused by calling setBlurMipmap() before texture is…

### DIFF
--- a/src/main/java/thebetweenlands/client/handler/WorldRenderHandler.java
+++ b/src/main/java/thebetweenlands/client/handler/WorldRenderHandler.java
@@ -78,9 +78,9 @@ public class WorldRenderHandler {
 
 		ITextureObject texture = MC.getTextureManager().getTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
 
-		texture.setBlurMipmap(true, false);
-
 		MC.getTextureManager().bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+
+		texture.setBlurMipmap(true, false);
 
 		Tessellator tessellator = Tessellator.getInstance();
 		BufferBuilder vertexBuffer = tessellator.getBuffer();


### PR DESCRIPTION
… bound in RenderWorldLastEvent

To reproduce, install Charset (latest CI build or CurseForge version), place a barrel in the world and cause it to pop up a notice. The Betweenlands's event handler will trigger after Charset's (at least if the mods are loaded in this order) and setBlurMipmap() on the Minecraft font texture, as that would be the bound texture then if a notice was being rendered. As restoreLastBlurMipmap() is called on the correct texture (the block sheet), the font's blur and mipmap settings will never be restored.

![](https://img.asie.pl/tfHw)
  
  
  