### PR TITLE
WIP: Optimize inventory tick logic

### DIFF
--- a/src/main/java/thebetweenlands/api/capability/IEquipmentCapability.java
+++ b/src/main/java/thebetweenlands/api/capability/IEquipmentCapability.java
@@ -1,6 +1,7 @@
 package thebetweenlands.api.capability;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
@@ -55,4 +56,23 @@ public interface IEquipmentCapability {
 	 * @param slots
 	 */
 	public void setAmuletSlots(int slots);
+
+	/**
+	 * Performs a tick for all {@link ITickable} inventories. Called for every entity with this capability
+	 * on {@link net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent}.
+	 */
+	void tickInventories();
+
+	/**
+	 * Returns the inventory for the specified type if it has been lazily initialized. This is useful for avoiding
+	 * instantiation when we're only querying in render code or on tick. This should be used instead of
+	 * {@link IEquipmentCapability#getInventory(EnumEquipmentInventory)} when not modifying an inventory.
+	 *
+	 * See {@link IEquipmentCapability#getInventory(EnumEquipmentInventory)} for additional information.
+	 * 
+ 	 * @param type The {@link EnumEquipmentInventory} of the inventory
+	 * @return The inventory belonging to {@param type} if it has been lazily initialized, otherwise null
+	 */
+	@Nullable
+	IInventory getInventoryIfPresent(EnumEquipmentInventory type);
 }

--- a/src/main/java/thebetweenlands/api/item/IEquippable.java
+++ b/src/main/java/thebetweenlands/api/item/IEquippable.java
@@ -96,10 +96,12 @@ public interface IEquippable {
 			public float apply(ItemStack stack, @Nullable World world, @Nullable EntityLivingBase entity) {
 				if(stack.getItem() instanceof IEquippable && entity != null && entity.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
 					IEquipmentCapability cap = entity.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-					IInventory inv = cap.getInventory(((IEquippable) stack.getItem()).getEquipmentCategory(stack));
-					for(int i = 0; i < inv.getSizeInventory(); i++) {
-						if(stack == inv.getStackInSlot(i)) {
-							return 1;
+					IInventory inv = cap.getInventoryIfPresent(((IEquippable) stack.getItem()).getEquipmentCategory(stack));
+					if (inv != null) {
+						for(int i = 0; i < inv.getSizeInventory(); i++) {
+							if(stack == inv.getStackInSlot(i)) {
+								return 1;
+							}
 						}
 					}
 				}

--- a/src/main/java/thebetweenlands/client/handler/ScreenRenderHandler.java
+++ b/src/main/java/thebetweenlands/client/handler/ScreenRenderHandler.java
@@ -349,7 +349,11 @@ public class ScreenRenderHandler extends Gui {
 					int yOffset = 0;
 
 					for(EnumEquipmentInventory type : EnumEquipmentInventory.values()) {
-						IInventory inv = capability.getInventory(type);
+						IInventory inv = capability.getInventoryIfPresent(type);
+
+						if (inv == null) {
+							continue;
+						}
 
 						int xOffset = 0;
 						

--- a/src/main/java/thebetweenlands/client/handler/equipment/RadialMenuHandler.java
+++ b/src/main/java/thebetweenlands/client/handler/equipment/RadialMenuHandler.java
@@ -160,7 +160,10 @@ public class RadialMenuHandler {
 
 				//Unequippable items
 				for(EnumEquipmentInventory type : EnumEquipmentInventory.values()) {
-					IInventory inv = cap.getInventory(type);
+					IInventory inv = cap.getInventoryIfPresent(type);
+					if (inv == null) {
+						continue;
+					}
 
 					for(int i = 0; i < inv.getSizeInventory(); i++) {
 						ItemStack stack = inv.getStackInSlot(i);

--- a/src/main/java/thebetweenlands/common/capability/equipment/EnumEquipmentInventory.java
+++ b/src/main/java/thebetweenlands/common/capability/equipment/EnumEquipmentInventory.java
@@ -7,6 +7,8 @@ import net.minecraft.inventory.IInventory;
 public enum EnumEquipmentInventory {
 	MISC(3, 32), AMULET(1, 3), RING(2, 2);
 
+	public static final EnumEquipmentInventory[] VALUES = EnumEquipmentInventory.values();
+
 	/**
 	 * The ID of this inventory
 	 */

--- a/src/main/java/thebetweenlands/common/capability/equipment/EquipmentEntityCapability.java
+++ b/src/main/java/thebetweenlands/common/capability/equipment/EquipmentEntityCapability.java
@@ -10,17 +10,21 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+import net.minecraft.util.ITickable;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants;
 import thebetweenlands.api.capability.IEquipmentCapability;
 import thebetweenlands.api.capability.ISerializableCapability;
+import thebetweenlands.common.TheBetweenlands;
 import thebetweenlands.common.capability.base.EntityCapability;
 import thebetweenlands.common.inventory.InventoryEquipment;
 import thebetweenlands.common.inventory.InventoryEquipmentAmulets;
 import thebetweenlands.common.lib.ModInfo;
 import thebetweenlands.common.registries.CapabilityRegistry;
+
+import javax.annotation.Nullable;
 
 public class EquipmentEntityCapability extends EntityCapability<EquipmentEntityCapability, IEquipmentCapability, EntityPlayer> implements IEquipmentCapability, ISerializableCapability {
 	private Map<EnumEquipmentInventory, NonNullList<ItemStack>> allInventoryStacks = new EnumMap<>(EnumEquipmentInventory.class);
@@ -162,5 +166,28 @@ public class EquipmentEntityCapability extends EntityCapability<EquipmentEntityC
 	@Override
 	public void setAmuletSlots(int slots) {
 		this.amuletSlots = slots;
+	}
+
+	@Override
+	public void tickInventories() {
+		for(EnumEquipmentInventory invType : EnumEquipmentInventory.VALUES) {
+			// Avoids instantiating inventories if they have not been lazily initialized yet
+			IInventory inventory = this.inventories.get(invType);
+
+			// Also doubles as a null check!
+			if(inventory instanceof ITickable) {
+				((ITickable) inventory).update();
+			}
+
+			if(inventory.isEmpty()) {
+				this.inventories.remove(invType);
+			}
+		}
+	}
+
+	@Nullable
+	@Override
+	public IInventory getInventoryIfPresent(EnumEquipmentInventory type) {
+		return this.inventories.get(type);
 	}
 }

--- a/src/main/java/thebetweenlands/common/capability/equipment/EquipmentEntityCapability.java
+++ b/src/main/java/thebetweenlands/common/capability/equipment/EquipmentEntityCapability.java
@@ -170,17 +170,10 @@ public class EquipmentEntityCapability extends EntityCapability<EquipmentEntityC
 
 	@Override
 	public void tickInventories() {
-		for(EnumEquipmentInventory invType : EnumEquipmentInventory.VALUES) {
-			// Avoids instantiating inventories if they have not been lazily initialized yet
-			IInventory inventory = this.inventories.get(invType);
-
+		for(IInventory inventory : this.inventories.values()) {
 			// Also doubles as a null check!
 			if(inventory instanceof ITickable) {
 				((ITickable) inventory).update();
-			}
-
-			if(inventory.isEmpty()) {
-				this.inventories.remove(invType);
 			}
 		}
 	}

--- a/src/main/java/thebetweenlands/common/capability/equipment/EquipmentHelper.java
+++ b/src/main/java/thebetweenlands/common/capability/equipment/EquipmentHelper.java
@@ -28,7 +28,10 @@ public class EquipmentHelper {
 	public static ItemStack getEquipment(EnumEquipmentInventory inventory, Entity entity, Item item) {
 		if(entity.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
 			IEquipmentCapability cap = entity.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-			IInventory mainInv = cap.getInventory(inventory);
+			IInventory mainInv = cap.getInventoryIfPresent(inventory);
+			if (mainInv == null) {
+				return ItemStack.EMPTY;
+			}
 			for(int i = 0; i < mainInv.getSizeInventory(); i++) {
 				ItemStack stack = mainInv.getStackInSlot(i);
 				if(!stack.isEmpty() && stack.getItem() == item) {

--- a/src/main/java/thebetweenlands/common/handler/AttackDamageHandler.java
+++ b/src/main/java/thebetweenlands/common/handler/AttackDamageHandler.java
@@ -133,21 +133,23 @@ public class AttackDamageHandler {
 
 			if(attacker.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
 				IEquipmentCapability cap = attacker.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-				IInventory inv = cap.getInventory(EnumEquipmentInventory.RING);
-				int rings = 0;
+				IInventory inv = cap.getInventoryIfPresent(EnumEquipmentInventory.RING);
+				if (inv != null) {
+					int rings = 0;
 
-				for(int i = 0; i < inv.getSizeInventory(); i++) {
-					ItemStack stack = inv.getStackInSlot(i);
-					if(!stack.isEmpty() && stack.getItem() == ItemRegistry.RING_OF_POWER) {
-						rings++;
+					for(int i = 0; i < inv.getSizeInventory(); i++) {
+						ItemStack stack = inv.getStackInSlot(i);
+						if(!stack.isEmpty() && stack.getItem() == ItemRegistry.RING_OF_POWER) {
+							rings++;
+						}
 					}
-				}
 
-				if(rings > 0) {
-					TheBetweenlands.networkWrapper.sendToAllAround(new MessagePowerRingParticles(attackedEntity), new TargetPoint(attackedEntity.dimension, attackedEntity.posX, attackedEntity.posY, attackedEntity.posZ, 32.0D));
-				}
+					if(rings > 0) {
+						TheBetweenlands.networkWrapper.sendToAllAround(new MessagePowerRingParticles(attackedEntity), new TargetPoint(attackedEntity.dimension, attackedEntity.posX, attackedEntity.posY, attackedEntity.posZ, 32.0D));
+					}
 
-				damage *= 1.0F + 0.5F * rings;
+					damage *= 1.0F + 0.5F * rings;
+				}
 			}
 		}
 

--- a/src/main/java/thebetweenlands/common/handler/ItemEquipmentHandler.java
+++ b/src/main/java/thebetweenlands/common/handler/ItemEquipmentHandler.java
@@ -7,7 +7,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHand;
-import net.minecraft.util.ITickable;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.event.entity.living.LivingDropsEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
@@ -33,13 +32,7 @@ public class ItemEquipmentHandler {
 			return;
 		}
 
-		for(EnumEquipmentInventory invType : EnumEquipmentInventory.VALUES) {
-			IInventory inventory = cap.getInventory(invType);
-
-			if(inventory instanceof ITickable) {
-				((ITickable) inventory).update();
-			}
-		}
+		cap.tickInventories();
 	}
 
 
@@ -157,7 +150,11 @@ public class ItemEquipmentHandler {
 				IEquipmentCapability cap = entity.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
 
 				for(EnumEquipmentInventory type : EnumEquipmentInventory.values()) {
-					IInventory inv = cap.getInventory(type);
+					IInventory inv = cap.getInventoryIfPresent(type);
+
+					if (inv == null) {
+						continue;
+					}
 
 					for(int i = 0; i < inv.getSizeInventory(); i++) {
 						ItemStack stack = inv.getStackInSlot(i);

--- a/src/main/java/thebetweenlands/common/inventory/InventoryEquipment.java
+++ b/src/main/java/thebetweenlands/common/inventory/InventoryEquipment.java
@@ -160,7 +160,7 @@ public class InventoryEquipment implements IInventory, ITickable {
         for (int i = 0; i < this.inventory.size(); i++) {
             ItemStack stack = this.inventory.get(i);
 
-            if (!stack.isEmpty() && stack.getItem() instanceof IEquippable) {
+            if (stack.getItem() instanceof IEquippable) {
                 ((IEquippable) stack.getItem()).onEquipmentTick(stack, this.capability.getEntity(), this);
             }
         }

--- a/src/main/java/thebetweenlands/common/inventory/container/ContainerPouch.java
+++ b/src/main/java/thebetweenlands/common/inventory/container/ContainerPouch.java
@@ -71,13 +71,15 @@ public class ContainerPouch extends Container {
 		//Check if pouch is in equipment
 		if (player.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
             IEquipmentCapability cap = player.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-            IInventory inv = cap.getInventory(EnumEquipmentInventory.MISC);
+            IInventory inv = cap.getInventoryIfPresent(EnumEquipmentInventory.MISC);
 
-            for (int i = 0; i < inv.getSizeInventory(); i++) {
-                if (inv.getStackInSlot(i) == this.inventory.getInventoryItemStack()) {
-                    return true;
-                }
-            }
+            if (inv != null) {
+				for (int i = 0; i < inv.getSizeInventory(); i++) {
+					if (inv.getStackInSlot(i) == this.inventory.getInventoryItemStack()) {
+						return true;
+					}
+				}
+			}
         }
 		
 		//Check if pouch is in main inventory

--- a/src/main/java/thebetweenlands/common/item/equipment/ItemAmulet.java
+++ b/src/main/java/thebetweenlands/common/item/equipment/ItemAmulet.java
@@ -7,8 +7,6 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
-import org.lwjgl.input.Keyboard;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.GlStateManager;
@@ -125,7 +123,10 @@ public class ItemAmulet extends Item implements IEquippable {
 		
 		if (entity.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
 			IEquipmentCapability cap = entity.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-			IInventory inv = cap.getInventory(EnumEquipmentInventory.AMULET);
+			IInventory inv = cap.getInventoryIfPresent(EnumEquipmentInventory.AMULET);
+			if (inv == null) {
+				return;
+			}
 			List<ItemStack> items = new ArrayList<ItemStack>(inv.getSizeInventory());
 
 			for (int i = 0; i < inv.getSizeInventory(); i++) {

--- a/src/main/java/thebetweenlands/common/item/equipment/ItemLurkerSkinPouch.java
+++ b/src/main/java/thebetweenlands/common/item/equipment/ItemLurkerSkinPouch.java
@@ -79,12 +79,14 @@ public class ItemLurkerSkinPouch extends Item implements IEquippable, IRenamable
     public static ItemStack getFirstPouch(EntityPlayer player) {
         if (player.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
             IEquipmentCapability cap = player.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-            IInventory inv = cap.getInventory(EnumEquipmentInventory.MISC);
+            IInventory inv = cap.getInventoryIfPresent(EnumEquipmentInventory.MISC);
 
-            for (int i = 0; i < inv.getSizeInventory(); i++) {
-                ItemStack stack = inv.getStackInSlot(i);
-                if (!stack.isEmpty() && stack.getItem() == ItemRegistry.LURKER_SKIN_POUCH) {
-                    return stack;
+            if (inv != null) {
+                for (int i = 0; i < inv.getSizeInventory(); i++) {
+                    ItemStack stack = inv.getStackInSlot(i);
+                    if (!stack.isEmpty() && stack.getItem() == ItemRegistry.LURKER_SKIN_POUCH) {
+                        return stack;
+                    }
                 }
             }
         }
@@ -186,17 +188,19 @@ public class ItemLurkerSkinPouch extends Item implements IEquippable, IRenamable
 	private static void renderPouch(EntityPlayer player, double x, double y, double z, float partialTicks) {
 		if(player.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
 			IEquipmentCapability cap = player.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-			IInventory inv = cap.getInventory(EnumEquipmentInventory.MISC);
+			IInventory inv = cap.getInventoryIfPresent(EnumEquipmentInventory.MISC);
 
 			ItemStack pouch = null;
 
-			for(int i = 0; i < inv.getSizeInventory(); i++) {
-				ItemStack stack = inv.getStackInSlot(i);
-				if(stack != null && stack.getItem() == ItemRegistry.LURKER_SKIN_POUCH) {
-					pouch = stack;
-					break;
-				}
-			}
+			if (inv != null) {
+                for(int i = 0; i < inv.getSizeInventory(); i++) {
+                    ItemStack stack = inv.getStackInSlot(i);
+                    if(stack != null && stack.getItem() == ItemRegistry.LURKER_SKIN_POUCH) {
+                        pouch = stack;
+                        break;
+                    }
+                }
+            }
 
 			if(pouch != null) {
 				TextureManager textureManager = Minecraft.getMinecraft().getTextureManager();

--- a/src/main/java/thebetweenlands/common/item/equipment/ItemRingOfFlight.java
+++ b/src/main/java/thebetweenlands/common/item/equipment/ItemRingOfFlight.java
@@ -172,12 +172,14 @@ public class ItemRingOfFlight extends ItemRing {
 
 					if(player.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
 						IEquipmentCapability equipmentCap = player.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-						IInventory inv = equipmentCap.getInventory(EnumEquipmentInventory.RING);
-						for(int i = 0; i < inv.getSizeInventory(); i++) {
-							ItemStack stack = inv.getStackInSlot(i);
-							if(!stack.isEmpty() && stack.getItem() == ItemRegistry.RING_OF_FLIGHT) {
-								flightRing = stack;
-								break;
+						IInventory inv = equipmentCap.getInventoryIfPresent(EnumEquipmentInventory.RING);
+						if (inv != null) {
+							for(int i = 0; i < inv.getSizeInventory(); i++) {
+								ItemStack stack = inv.getStackInSlot(i);
+								if(!stack.isEmpty() && stack.getItem() == ItemRegistry.RING_OF_FLIGHT) {
+									flightRing = stack;
+									break;
+								}
 							}
 						}
 					}

--- a/src/main/java/thebetweenlands/common/item/equipment/ItemRingOfRecruitment.java
+++ b/src/main/java/thebetweenlands/common/item/equipment/ItemRingOfRecruitment.java
@@ -88,15 +88,17 @@ public class ItemRingOfRecruitment extends ItemRing {
 
 		if(entity.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
 			IEquipmentCapability cap = entity.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-			IInventory inv = cap.getInventory(EnumEquipmentInventory.RING);
+			IInventory inv = cap.getInventoryIfPresent(EnumEquipmentInventory.RING);
 
 			boolean hasRing = false;
 
-			for(int i = 0; i < inv.getSizeInventory(); i++) {
-				ItemStack stack = inv.getStackInSlot(i);
-				if(!stack.isEmpty() && stack.getItem() == ItemRegistry.RING_OF_RECRUITMENT) {
-					hasRing = true;
-					break;
+			if (inv != null) {
+				for(int i = 0; i < inv.getSizeInventory(); i++) {
+					ItemStack stack = inv.getStackInSlot(i);
+					if(!stack.isEmpty() && stack.getItem() == ItemRegistry.RING_OF_RECRUITMENT) {
+						hasRing = true;
+						break;
+					}
 				}
 			}
 

--- a/src/main/java/thebetweenlands/common/item/equipment/ItemRingOfSummoning.java
+++ b/src/main/java/thebetweenlands/common/item/equipment/ItemRingOfSummoning.java
@@ -136,15 +136,17 @@ public class ItemRingOfSummoning extends ItemRing {
 	public static boolean isRingActive(Entity entity) {
 		if(entity.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
 			IEquipmentCapability cap = entity.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-			IInventory inv = cap.getInventory(EnumEquipmentInventory.RING);
+			IInventory inv = cap.getInventoryIfPresent(EnumEquipmentInventory.RING);
 
 			boolean hasRing = false;
 
-			for(int i = 0; i < inv.getSizeInventory(); i++) {
-				ItemStack stack = inv.getStackInSlot(i);
-				if(!stack.isEmpty() && stack.getItem() == ItemRegistry.RING_OF_SUMMONING && ((ItemRing) stack.getItem()).canBeUsed(stack)) {
-					hasRing = true;
-					break;
+			if (inv != null) {
+				for(int i = 0; i < inv.getSizeInventory(); i++) {
+					ItemStack stack = inv.getStackInSlot(i);
+					if(!stack.isEmpty() && stack.getItem() == ItemRegistry.RING_OF_SUMMONING && ((ItemRing) stack.getItem()).canBeUsed(stack)) {
+						hasRing = true;
+						break;
+					}
 				}
 			}
 

--- a/src/main/java/thebetweenlands/common/network/serverbound/MessageFlightState.java
+++ b/src/main/java/thebetweenlands/common/network/serverbound/MessageFlightState.java
@@ -43,12 +43,14 @@ public class MessageFlightState extends MessageBase {
 
 				if(player.hasCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null)) {
 					IEquipmentCapability equipmentCap = player.getCapability(CapabilityRegistry.CAPABILITY_EQUIPMENT, null);
-					IInventory inv = equipmentCap.getInventory(EnumEquipmentInventory.RING);
-					for(int i = 0; i < inv.getSizeInventory(); i++) {
-						ItemStack stack = inv.getStackInSlot(i);
-						if(!stack.isEmpty() && stack.getItem() == ItemRegistry.RING_OF_FLIGHT) {
-							canPlayerFly = true;
-							break;
+					IInventory inv = equipmentCap.getInventoryIfPresent(EnumEquipmentInventory.RING);
+					if (inv != null) {
+						for(int i = 0; i < inv.getSizeInventory(); i++) {
+							ItemStack stack = inv.getStackInSlot(i);
+							if(!stack.isEmpty() && stack.getItem() == ItemRegistry.RING_OF_FLIGHT) {
+								canPlayerFly = true;
+								break;
+							}
 						}
 					}
 				}

--- a/src/main/java/thebetweenlands/compat/tmg/TMGEquipmentInventory.java
+++ b/src/main/java/thebetweenlands/compat/tmg/TMGEquipmentInventory.java
@@ -37,12 +37,14 @@ public class TMGEquipmentInventory extends AbstractSpecialInventory {
             EnumEquipmentInventory[] equipmentInventories = EnumEquipmentInventory.values();
 
             for (EnumEquipmentInventory type : equipmentInventories) {
-                IInventory inv = equipmentCapability.getInventory(type);
+                IInventory inv = equipmentCapability.getInventoryIfPresent(type);
 
-                NBTTagList tagList = SpecialInventoryHelper.getTagListFromIInventory(inv);
-                if (tagList != null) {
-                    compound.setTag(type.ordinal() + "", tagList);
-                    setTag = true;
+                if (inv != null) {
+                    NBTTagList tagList = SpecialInventoryHelper.getTagListFromIInventory(inv);
+                    if (tagList != null) {
+                        compound.setTag(type.ordinal() + "", tagList);
+                        setTag = true;
+                    }
                 }
             }
 


### PR DESCRIPTION
The original code behind ticking equipment inventories worked by iterating over every entity each tick, which is not particularly fast when there are many non-living entities. The previous implementation also doesn't follow the best practices for updating capabilities, being that it should be done during the tick for each entity.

This commit makes the following changes to reduce the amount of time being spent ticking inventories:
- Forge's `LivingUpdateEvent` is used instead of iterating over every entity in the world again ourselves, providing a decent improvement by itself
- The `ICapabilityProvider#hasCapability` check has been removed and replaced for a simple null check on the result returned by `ICapabilityProvider#getCapability` as it is unnecessary to check if a capability is present before fetching it (the only use of `ICapabilityProvider#hasCapability` is as a faster check when the capability instance is not needed)
- The usage of `EnumEquipmentInventory#values()` has been replaced with a cached array, as  `Enum#values()` creates a new array each time

After these changes, the amount of CPU time spent by inventory ticking is reduced to essentially nothing and is no longer visible in profiling data, where before it would account for upwards of 3-4% of a tick's CPU time.