### PR TITLE
Stop wight fortresses spawning on giant roots/floating islands

### DIFF
--- a/src/main/java/thebetweenlands/common/world/gen/biome/decorator/DecorationHelper.java
+++ b/src/main/java/thebetweenlands/common/world/gen/biome/decorator/DecorationHelper.java
@@ -860,7 +860,7 @@ public class DecorationHelper {
 	}
 
 	public static boolean generateWightFortress(DecoratorPositionProvider decorator) {
-		BlockPos pos = decorator.getRandomPos(1);
+		BlockPos pos = decorator.getRandomPosSeaGround(1);
 		if(decorator.getWorld().isAirBlock(pos) && SurfaceType.MIXED_GROUND.matches(decorator.getWorld(), pos.down())) {
 			Biome biome = decorator.getWorld().getBiome(pos);
 			WorldGenWightFortress fortress = new WorldGenWightFortress();


### PR DESCRIPTION
Use getRandomPosSeaGround instead of getRandomPos to generate a wight fortress (the Giant Weedwood Tree also uses this function), so that it will not generate on giant roots or floating islands, due to not querying those blocks, the Giant Weedwood Tree also does this, and *it* doesn't spawn on floating islands or giant roots