### PR TITLE
Add IAnimals tag to certain mobs for better mod compat

### DIFF
--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityAnadia.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityAnadia.java
@@ -59,7 +59,7 @@ import thebetweenlands.common.registries.SoundRegistry;
 import thebetweenlands.common.world.WorldProviderBetweenlands;
 import thebetweenlands.util.TranslationHelper;
 
-public class EntityAnadia extends EntityCreature implements IEntityBL {
+public class EntityAnadia extends EntityCreature implements IEntityBL, net.minecraft.entity.passive.IAnimals {
 
 	private static final DataParameter<Float> FISH_SIZE = EntityDataManager.<Float>createKey(EntityAnadia.class, DataSerializers.FLOAT);
 	private static final DataParameter<Byte> HEAD_TYPE = EntityDataManager.<Byte>createKey(EntityAnadia.class, DataSerializers.BYTE);

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityCaveFish.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityCaveFish.java
@@ -45,7 +45,7 @@ import thebetweenlands.common.registries.BlockRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 import thebetweenlands.common.world.WorldProviderBetweenlands;
 
-public class EntityCaveFish extends EntityCreature implements IEntityBL {
+public class EntityCaveFish extends EntityCreature implements IEntityBL, net.minecraft.entity.passive.IAnimals {
 
 	protected static final DataParameter<Boolean> IS_LEADER = EntityDataManager.<Boolean>createKey(EntityCaveFish.class, DataSerializers.BOOLEAN);
 	private EntityAIWander wanderAbout;

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityEmberling.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityEmberling.java
@@ -61,7 +61,7 @@ import thebetweenlands.common.registries.ItemRegistry;
 import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 
-public class EntityEmberling extends EntityTameableBL implements IEntityMultiPart, IRingOfGatheringMinion {
+public class EntityEmberling extends EntityTameableBL implements IEntityMultiPart, IRingOfGatheringMinion, net.minecraft.entity.passive.IAnimals {
 
 	public MultiPartEntityPart[] tailPart;
 	private static final DataParameter<Boolean> IS_FLAME_ATTACKING = EntityDataManager.<Boolean>createKey(EntityEmberling.class, DataSerializers.BOOLEAN);

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityEmberlingWild.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityEmberlingWild.java
@@ -45,7 +45,7 @@ import thebetweenlands.api.entity.IEntityBL;
 import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 
-public class EntityEmberlingWild extends EntityMob implements IEntityMultiPart, IEntityBL{
+public class EntityEmberlingWild extends EntityMob implements IEntityMultiPart, IEntityBL, net.minecraft.entity.passive.IAnimals {
 
 	public MultiPartEntityPart[] tailPart;
 	private static final DataParameter<Boolean> IS_FLAME_ATTACKING = EntityDataManager.<Boolean>createKey(EntityEmberlingWild.class, DataSerializers.BOOLEAN);

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityFirefly.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityFirefly.java
@@ -27,7 +27,7 @@ import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 import thebetweenlands.common.world.storage.BetweenlandsWorldStorage;
 
-public class EntityFirefly extends EntityFlyingCreature implements IEntityBL, IPullerEntityProvider<EntityPullerFirefly> {
+public class EntityFirefly extends EntityFlyingCreature implements IEntityBL, IPullerEntityProvider<EntityPullerFirefly>, net.minecraft.entity.passive.IAnimals {
 	public static final IAttribute GLOW_STRENGTH_ATTRIB = (new RangedAttribute(null, "bl.fireflyGlowStrength", 1, 0, 8)).setDescription("Firefly glow strength").setShouldWatch(true);
 	public static final IAttribute GLOW_START_CHANCE = (new RangedAttribute(null, "bl.fireflyGlowStartChance", 0.0025D, 0, 1)).setDescription("Firefly glow start chance per tick");
 	public static final IAttribute GLOW_STOP_CHANCE = (new RangedAttribute(null, "bl.fireflyGlowStopChance", 0.00083D, 0, 1)).setDescription("Firefly glow stop chance per tick");

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityFrog.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityFrog.java
@@ -31,7 +31,7 @@ import thebetweenlands.client.render.particle.BLParticles;
 import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 
-public class EntityFrog extends EntityCreature implements IEntityBL {
+public class EntityFrog extends EntityCreature implements IEntityBL, net.minecraft.entity.passive.IAnimals {
 	public static final IAttribute FROG_SKIN_ATTRIB = (new RangedAttribute(null, "bl.frogSkin", 0, 0, 5)).setDescription("Frog skin").setShouldWatch(true);
 
 	private static final DataParameter<Byte> DW_SWIM_STROKE = EntityDataManager.createKey(EntityFrog.class, DataSerializers.BYTE);

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityGecko.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityGecko.java
@@ -41,7 +41,7 @@ import thebetweenlands.common.registries.ItemRegistry;
 import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 
-public class EntityGecko extends EntityCreature implements IEntityBL, WeedWoodBushUncollidableEntity {
+public class EntityGecko extends EntityCreature implements IEntityBL, WeedWoodBushUncollidableEntity, net.minecraft.entity.passive.IAnimals {
 	private static final DataParameter<Boolean> HIDING = EntityDataManager.createKey(EntityGecko.class, DataSerializers.BOOLEAN);
 
 	private static final int MIN_HIDE_TIME = 20 * 60 * 2;

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityGiantToad.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityGiantToad.java
@@ -46,7 +46,7 @@ import thebetweenlands.common.registries.ItemRegistry;
 import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 
-public class EntityGiantToad extends EntityTameableBL implements IEntityBL, IRingOfGatheringMinion {
+public class EntityGiantToad extends EntityTameableBL implements IEntityBL, IRingOfGatheringMinion, net.minecraft.entity.passive.IAnimals {
 	private static final DataParameter<Byte> DW_SWIM_STROKE = EntityDataManager.createKey(EntityGiantToad.class, DataSerializers.BYTE);
 	private static final DataParameter<Boolean> DW_TAMED = EntityDataManager.createKey(EntityGiantToad.class, DataSerializers.BOOLEAN);
 

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityJellyfish.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityJellyfish.java
@@ -41,7 +41,7 @@ import thebetweenlands.common.registries.BlockRegistry;
 import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 
-public class EntityJellyfish extends EntityCreature implements IEntityBL, IEntityAdditionalSpawnData, IMob {
+public class EntityJellyfish extends EntityCreature implements IEntityBL, IEntityAdditionalSpawnData, IMob, net.minecraft.entity.passive.IAnimals {
 	protected Vec3d prevOrientationPos = Vec3d.ZERO;
 	protected Vec3d orientationPos = Vec3d.ZERO;
 

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityJellyfishCave.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityJellyfishCave.java
@@ -24,7 +24,7 @@ import thebetweenlands.client.render.particle.ParticleFactory.ParticleArgs;
 import thebetweenlands.common.entity.EntityShock;
 import thebetweenlands.common.registries.SoundRegistry;
 
-public class EntityJellyfishCave extends EntityJellyfish implements IMob {
+public class EntityJellyfishCave extends EntityJellyfish implements IMob, net.minecraft.entity.passive.IAnimals {
 	protected static final byte EVENT_SPARK = 80;
 
 	public EntityJellyfishCave(World world) {

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityLurker.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityLurker.java
@@ -52,7 +52,7 @@ import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 import thebetweenlands.util.MathUtils;
 
-public class EntityLurker extends EntityCreature implements IEntityBL, IMob {
+public class EntityLurker extends EntityCreature implements IEntityBL, IMob, net.minecraft.entity.passive.IAnimals {
     private static final DataParameter<Boolean> IS_LEAPING = EntityDataManager.createKey(EntityLurker.class, DataSerializers.BOOLEAN);
     private static final DataParameter<Boolean> SHOULD_MOUTH_BE_OPEN = EntityDataManager.createKey(EntityLurker.class, DataSerializers.BOOLEAN);
     private static final DataParameter<Float> MOUTH_MOVE_SPEED = EntityDataManager.createKey(EntityLurker.class, DataSerializers.FLOAT);

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityOlm.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityOlm.java
@@ -34,7 +34,7 @@ import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 import thebetweenlands.common.world.WorldProviderBetweenlands;
 
-public class EntityOlm extends EntityCreature implements IEntityBL {
+public class EntityOlm extends EntityCreature implements IEntityBL, net.minecraft.entity.passive.IAnimals {
 	public long egg_cooldown;
 
     public EntityOlm(World world) {

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityPuffin.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityPuffin.java
@@ -37,7 +37,7 @@ import thebetweenlands.common.entity.movement.FlightMoveHelper;
 import thebetweenlands.common.entity.movement.PathNavigateFlyingBL;
 import thebetweenlands.common.registries.SoundRegistry;
 
-public class EntityPuffin extends EntityCreature implements IEntityBL {
+public class EntityPuffin extends EntityCreature implements IEntityBL, net.minecraft.entity.passive.IAnimals {
 
 	private static final DataParameter<Boolean> IS_HOVERING = EntityDataManager.createKey(EntityPuffin.class, DataSerializers.BOOLEAN);
 	private static final DataParameter<Boolean> IS_DIVING = EntityDataManager.createKey(EntityPuffin.class, DataSerializers.BOOLEAN);

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntityRootSprite.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntityRootSprite.java
@@ -25,7 +25,7 @@ import thebetweenlands.common.entity.ai.EntityAIJumpRandomly;
 import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 
-public class EntityRootSprite extends EntityCreature implements IEntityBL {
+public class EntityRootSprite extends EntityCreature implements IEntityBL, net.minecraft.entity.passive.IAnimals {
 	private static final byte EVENT_STEP = 40;
 
 	private float jumpHeightOverride = -1;

--- a/src/main/java/thebetweenlands/common/entity/mobs/EntitySporeling.java
+++ b/src/main/java/thebetweenlands/common/entity/mobs/EntitySporeling.java
@@ -36,7 +36,7 @@ import thebetweenlands.common.registries.LootTableRegistry;
 import thebetweenlands.common.registries.SoundRegistry;
 import thebetweenlands.common.world.storage.BetweenlandsWorldStorage;
 
-public class EntitySporeling extends EntityCreature implements IEntityBL {
+public class EntitySporeling extends EntityCreature implements IEntityBL, net.minecraft.entity.passive.IAnimals {
 	private float jumpHeightOverride = -1;
 	
 	protected static final DataParameter<Boolean> IS_FALLING = EntityDataManager.<Boolean>createKey(EntitySporeling.class, DataSerializers.BOOLEAN);


### PR DESCRIPTION
The `IAnimals` tag is a empty interface built into minecraft, a few mods use it for some functionality that will (kinda) break in the betweenlands, due to mire snails being the only mob with it.
It's main use in vanilla is for mob tracking, but forge already tracks modded entities separately so this won't have an effect on gameplay, apart from better cross-mod compatibility