### PR TITLE
add REAL_FACING_DIRECTION check

### DIFF
--- a/src/main/java/thebetweenlands/common/entity/EntityBLItemFrame.java
+++ b/src/main/java/thebetweenlands/common/entity/EntityBLItemFrame.java
@@ -172,7 +172,9 @@ public class EntityBLItemFrame extends EntityItemFrame implements IEntityAdditio
         dataManager.set(IS_GLOWING, compound.getBoolean("IS_GLOWING"));
         super.readEntityFromNBT(compound);
 
-        this.updateFacingWithBoundingBox(EnumFacing.byIndex(compound.getByte("REAL_FACING_DIRECTION")));
+        if(compound.hasKey("REAL_FACING_DIRECTION")) {
+            this.updateFacingWithBoundingBox(EnumFacing.byIndex(compound.getByte("REAL_FACING_DIRECTION")));
+        }
     }
 
     @Override

--- a/src/main/java/thebetweenlands/common/entity/EntityBLItemFrame.java
+++ b/src/main/java/thebetweenlands/common/entity/EntityBLItemFrame.java
@@ -172,7 +172,7 @@ public class EntityBLItemFrame extends EntityItemFrame implements IEntityAdditio
         dataManager.set(IS_GLOWING, compound.getBoolean("IS_GLOWING"));
         super.readEntityFromNBT(compound);
 
-        if(compound.hasKey("REAL_FACING_DIRECTION")) {
+        if(compound.hasKey("REAL_FACING_DIRECTION") || !compound.hasKey("Facing")) {
             this.updateFacingWithBoundingBox(EnumFacing.byIndex(compound.getByte("REAL_FACING_DIRECTION")));
         }
     }


### PR DESCRIPTION
in case it doesn't exist (e.g. summoned by commands)

basically so commands that summon vanilla item frames work the same way on BL ones