### PR TITLE
Fix swamp water pulling current from non-adjacent blocks

### DIFF
--- a/src/main/java/thebetweenlands/common/block/terrain/BlockSwampWater.java
+++ b/src/main/java/thebetweenlands/common/block/terrain/BlockSwampWater.java
@@ -328,11 +328,7 @@ public class BlockSwampWater extends BlockFluidClassic implements IStateMappedBl
 		if (!(state.getBlock() instanceof BlockSwampWater && ((BlockSwampWater) state.getBlock()).isUnderwaterBlock)) {
 			// check adjacent block levels if non-source
 			if (quantaRemaining < quantaPerBlock) {
-				if (world.getBlockState(pos.add(0, -densityDir, 0)).getBlock() == this ||
-						world.getBlockState(pos.add(-1, -densityDir, 0)).getBlock() == this ||
-						world.getBlockState(pos.add(1, -densityDir, 0)).getBlock() == this ||
-						world.getBlockState(pos.add(0, -densityDir, -1)).getBlock() == this ||
-						world.getBlockState(pos.add(0, -densityDir, 1)).getBlock() == this) {
+				if (world.getBlockState(pos.add(0, -densityDir, 0)).getBlock() == this) {
 					expQuanta = quantaPerBlock - 1;
 				} else {
 					int maxQuanta = -100;


### PR DESCRIPTION
Swamp water would still have a current if it was flowing over an edge (seen [here](https://youtu.be/YS22dYR6tjg)) and it was cut off from its source, this fixes that