### PR TITLE
Replace improper usage of BetweenlandsWorldStorage.forWorld()

### DIFF
--- a/src/main/java/thebetweenlands/common/command/CommandBLEvent.java
+++ b/src/main/java/thebetweenlands/common/command/CommandBLEvent.java
@@ -116,7 +116,7 @@ public class CommandBLEvent extends CommandBase {
 
 	@Override
 	public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos) {
-		if (BetweenlandsWorldStorage.forWorld(sender.getEntityWorld()) == null) {
+		if (BetweenlandsWorldStorage.forWorldNullable(sender.getEntityWorld()) == null) {
 			return Collections.<String>emptyList();
 		}
 		List<String> completions = null;

--- a/src/main/java/thebetweenlands/common/handler/EnvironmentEventHandler.java
+++ b/src/main/java/thebetweenlands/common/handler/EnvironmentEventHandler.java
@@ -26,7 +26,7 @@ public class EnvironmentEventHandler {
 	@SubscribeEvent
 	public static void onWorldTick(WorldTickEvent event) {
 		if(event.phase == Phase.END && !event.world.isRemote) {
-			BetweenlandsWorldStorage storage = BetweenlandsWorldStorage.forWorld(event.world);
+			BetweenlandsWorldStorage storage = BetweenlandsWorldStorage.forWorldNullable(event.world);
 
 			if(storage != null) {
 				BLEnvironmentEventRegistry reg = storage.getEnvironmentEventRegistry();


### PR DESCRIPTION
`BetweenlandsWorldStorage.forWorld(world)` will throw an error if the specified world is missing the capability, the correct usage in these cases is `BetweenlandsWorldStorage.forWorldNullable(world)`