### PR TITLE
Make the blessing effect guaranteed to teleport a player that fell into the void

### DIFF
--- a/src/main/java/thebetweenlands/common/tile/TileEntitySimulacrum.java
+++ b/src/main/java/thebetweenlands/common/tile/TileEntitySimulacrum.java
@@ -697,7 +697,7 @@ public class TileEntitySimulacrum extends TileEntityRepeller implements ITickabl
 						player.world.spawnEntity(xpOrb);
 					}
 
-					if(entity.world.rand.nextBoolean()) {
+					if(entity.world.rand.nextBoolean() || entity.posY <= -64) {
 						BlockPos spawnPoint = PlayerRespawnHandler.getSpawnPointNearPos(entity.world, location, 8, false, 4, 0);
 
 						if(spawnPoint != null) {


### PR DESCRIPTION
Simply setting their health back to half of their max health doesn't really work if they're in the void, so it should be guaranteed to teleport them back