### PR TITLE
Change Wisps to drop with getDrops

### DIFF
--- a/src/main/java/thebetweenlands/common/block/terrain/BlockWisp.java
+++ b/src/main/java/thebetweenlands/common/block/terrain/BlockWisp.java
@@ -86,7 +86,7 @@ public class BlockWisp extends BlockContainer implements IStateMappedBlock {
 	@Override
 	public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune) {
 		super.getDrops(drops, world, pos, state, fortune);
-		if(state.getValue(VISIBLE)) {
+		if(state.getValue(VISIBLE) && harvesters.get() != null) {
 			drops.add(new ItemStack(Item.getItemFromBlock(this), 1));
 		}
 	}

--- a/src/main/java/thebetweenlands/common/block/terrain/BlockWisp.java
+++ b/src/main/java/thebetweenlands/common/block/terrain/BlockWisp.java
@@ -34,6 +34,8 @@ import thebetweenlands.common.world.storage.location.LocationCragrockTower;
 import thebetweenlands.common.world.storage.location.LocationSpiritTree;
 import thebetweenlands.util.AdvancedStateMap.Builder;
 
+import net.minecraft.util.NonNullList;
+
 public class BlockWisp extends BlockContainer implements IStateMappedBlock {
 	protected static final AxisAlignedBB WISP_AABB = new AxisAlignedBB(0.2F, 0.2F, 0.2F, 0.8F, 0.8F, 0.8F);
 
@@ -73,11 +75,19 @@ public class BlockWisp extends BlockContainer implements IStateMappedBlock {
 		return null;
 	}
 
+	// @Override
+	// public void onPlayerDestroy(World world, BlockPos pos, IBlockState state) {
+	// 	if(!world.isRemote && state.getValue(VISIBLE)) {
+	// 		EntityItem wispItem = new EntityItem(world, pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, new ItemStack(Item.getItemFromBlock(this), 1));
+	// 		world.spawnEntity(wispItem);
+	// 	}
+	// }
+
 	@Override
-	public void onPlayerDestroy(World world, BlockPos pos, IBlockState state) {
-		if(!world.isRemote && state.getValue(VISIBLE)) {
-			EntityItem wispItem = new EntityItem(world, pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, new ItemStack(Item.getItemFromBlock(this), 1));
-			world.spawnEntity(wispItem);
+	public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune) {
+		super.getDrops(drops, world, pos, state, fortune);
+		if(state.getValue(VISIBLE)) {
+			drops.add(new ItemStack(Item.getItemFromBlock(this), 1));
 		}
 	}
 


### PR DESCRIPTION
Mainly for compatibility with other mods (e.g. an enchantment that automatically captures drops from broken blocks and places them in the user's inventory)

Also, this should properly interact with the `doTileDrops` gamerule