### PR TITLE
Add REACH_DISTANCE support to extended reach items

### DIFF
--- a/src/main/java/thebetweenlands/api/item/IExtendedReach.java
+++ b/src/main/java/thebetweenlands/api/item/IExtendedReach.java
@@ -1,15 +1,35 @@
 package thebetweenlands.api.item;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
 public interface IExtendedReach {
 
     /**
+     * Returns the reach modifier in blocks
+     * @return
+     */
+    double getReachModifier(@Nullable EntityPlayer player, ItemStack stack);
+	
+    /**
      * Returns the reach in blocks that the item will be able to hit
      * @return
      */
-    double getReach();
+    default double getReach(@Nullable EntityPlayer player, ItemStack stack) {
+    	if(player != null) {
+    		//PlayerController#attackEntity() is called from Minecraft#clickMouse()
+    		//Minecraft#clickMouse() uses Minecraft.objectMouseOver to determine if you're looking at an entity
+    		//EntityRenderer#getMouseOver() is the only place Minecraft.objectMouseOver is assigned
+    		//The raycast distance for Minecraft.objectMouseOver uses PlayerController#getBlockReachDistance()
+    		final double reach = player.getEntityAttribute(EntityPlayer.REACH_DISTANCE).getAttributeValue();
+    		return (player.isCreative() ? reach : reach - 0.5) + this.getReachModifier(player, stack);
+    	} else {
+    		//Assume survival mode (4.5 was assumed before this was introduced)
+    		return 4.5 + this.getReachModifier(player, stack);
+    	}
+    }
 
     default void onLeftClick(EntityPlayer player, ItemStack stack) {
     	

--- a/src/main/java/thebetweenlands/common/handler/ExtendedReachHandler.java
+++ b/src/main/java/thebetweenlands/common/handler/ExtendedReachHandler.java
@@ -130,7 +130,7 @@ public class ExtendedReachHandler {
             ItemStack stack = player.getHeldItem(EnumHand.MAIN_HAND);
             if (!stack.isEmpty()) {
                 if (stack.getItem() instanceof IExtendedReach) {
-                    double reach = ((IExtendedReach) stack.getItem()).getReach();
+                    double reach = ((IExtendedReach) stack.getItem()).getReach(player, stack);
                     RayTraceResult trace = getExtendedRayTrace(reach);
                     if (trace != null && trace.entityHit != null && trace.entityHit.hurtResistantTime == 0 && trace.entityHit != player) {
                         consumer.accept(trace);

--- a/src/main/java/thebetweenlands/common/item/tools/ItemAncientBattleAxe.java
+++ b/src/main/java/thebetweenlands/common/item/tools/ItemAncientBattleAxe.java
@@ -12,6 +12,7 @@ import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemStack;
@@ -51,11 +52,16 @@ public class ItemAncientBattleAxe extends ItemGreataxe {
 		return 2.2D;
 	}
 
-	@Override
-	public double getReach() {
-		return 3.5D;
-	}
+//	@Override
+//	public double getReach() {
+//		return 3.5D;
+//	}
 
+	@Override
+	public double getReachModifier(EntityPlayer player, ItemStack stack) {
+		return -1.0F;
+	}
+	
 	@Override
 	public Multimap<String, AttributeModifier> getAttributeModifiers(EntityEquipmentSlot equipmentSlot, ItemStack stack) {
 		if(equipmentSlot == EntityEquipmentSlot.MAINHAND && stack.getItemDamage() == stack.getMaxDamage()) {

--- a/src/main/java/thebetweenlands/common/item/tools/ItemGreataxe.java
+++ b/src/main/java/thebetweenlands/common/item/tools/ItemGreataxe.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.EnumRarity;
@@ -146,9 +147,14 @@ public class ItemGreataxe extends ItemGreatsword {
 		return 0;
 	}
 
+//	@Override
+//	public double getReach() {
+//		return 2.5D;
+//	}
+	
 	@Override
-	public double getReach() {
-		return 2.5D;
+	public double getReachModifier(EntityPlayer player, ItemStack stack) {
+		return -2.0F;
 	}
 
 	@Override

--- a/src/main/java/thebetweenlands/common/item/tools/ItemGreatsword.java
+++ b/src/main/java/thebetweenlands/common/item/tools/ItemGreatsword.java
@@ -250,9 +250,14 @@ public class ItemGreatsword extends ItemBLSword implements IExtendedReach, IBigS
 		return BLMaterialRegistry.getFullRepairLifeCost(BLMaterialRegistry.TOOL_LEGEND);
 	}
 
+//	@Override
+//	public double getReach() {
+//		return 5.5;
+//	}
+	
 	@Override
-	public double getReach() {
-		return 5.5;
+	public double getReachModifier(EntityPlayer player, ItemStack stack) {
+		return 1.0F;
 	}
 
 	@Override

--- a/src/main/java/thebetweenlands/common/network/serverbound/MessageExtendedReach.java
+++ b/src/main/java/thebetweenlands/common/network/serverbound/MessageExtendedReach.java
@@ -34,7 +34,7 @@ public class MessageExtendedReach extends MessageEntity {
 			for(Entity entity : entities) {
 				if (entity != null && entity.isEntityAlive()) {
 					double reach = ((IExtendedReach) heldItem.getItem()).getReach(player, heldItem);
-					if (player.isCreative() || reach * reach >= player.getPositionEyes(1.0F).squareDistanceTo(entity.getPositionVector())) {
+					if (player.isCreative() || entity.getEntityBoundingBox().grow(entity.getCollisionBorderSize() + reach).contains(player.getPositionEyes(1.0F))) {
 						player.attackTargetEntityWithCurrentItem(entity);
 					}
 				}

--- a/src/main/java/thebetweenlands/common/network/serverbound/MessageExtendedReach.java
+++ b/src/main/java/thebetweenlands/common/network/serverbound/MessageExtendedReach.java
@@ -33,8 +33,8 @@ public class MessageExtendedReach extends MessageEntity {
 			List<Entity> entities = this.getEntities();
 			for(Entity entity : entities) {
 				if (entity != null && entity.isEntityAlive()) {
-					double reach = ((IExtendedReach) heldItem.getItem()).getReach();
-					if (reach * reach >= player.getDistanceSq(entity)) {
+					double reach = ((IExtendedReach) heldItem.getItem()).getReach(player, heldItem);
+					if (player.isCreative() || reach * reach >= player.getPositionEyes(1.0F).squareDistanceTo(entity.getPositionVector())) {
 						player.attackTargetEntityWithCurrentItem(entity);
 					}
 				}


### PR DESCRIPTION
Adds `PlayerEntity.REACH_DISTANCE` support to greataxes and greatswords.  
Instead of statically setting the reach, it determines it based off of the player's current reach distance and an new reach modifier on top of that.