### PR TITLE
Fix Rubber Tree Planks treating recipe.

### DIFF
--- a/src/main/resources/assets/thebetweenlands/recipes/rubber_tree_planks_treated.json
+++ b/src/main/resources/assets/thebetweenlands/recipes/rubber_tree_planks_treated.json
@@ -10,10 +10,8 @@
       "item": "thebetweenlands:rubber_tree_planks"
     },
     "B": {
-      "type": "minecraft:item_nbt",
       "item": "thebetweenlands:bl_bucket_fish_oil",
-      "data": 32767,
-      "nbt": "{FluidName:\"fish_oil\",Amount:1000}"
+      "data": 32767
       }
   },
   "result": {


### PR DESCRIPTION
There was unnecessary NBT specification here which made the recipe uncraftable. Probably legacy from a forge-based fish oil bucket?